### PR TITLE
changed default to no color

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -8,7 +8,7 @@ separator = "="
 log_level = 1
 debug = false
 fatal = false
-color = true
+color = false
 
 [Brackets]
 # Keep matching elements at the same positions

--- a/docs/config.md
+++ b/docs/config.md
@@ -113,4 +113,4 @@ and turning it off (`--no-<OPTION>`). Only one command line argument can be used
 | Key       | CLI switches |Argument type      | Default | Description |
 |-----------|-----------|-------------|---------|------------|
 | fatal   | `--fatal`, `--no-fatal` | Boolean | `false` | When used all validators' warnings are fatal as errors. |
-| color   | `--color`/`--no-color` | Boolean | `true` | When `true`, application output will be using ANSI colors.|
+| color   | `--color`/`--no-color` | Boolean | `false` | When `true`, application output will be using ANSI colors.|

--- a/transtool/config/config.py
+++ b/transtool/config/config.py
@@ -41,7 +41,7 @@ class Config(object):
         self.fatal = False
 
         self.debug = False
-        self.color = True
+        self.color = False
         self.quiet: bool = False
         self.verbose: bool = False
 


### PR DESCRIPTION
Having `false` as default guaranties a good experience for all users, regardless the system they are on.